### PR TITLE
Update sensorage.js for 10 day sensors

### DIFF
--- a/lib/plugins/sensorage.js
+++ b/lib/plugins/sensorage.js
@@ -16,9 +16,9 @@ function init(ctx) {
 
   sage.getPrefs = function getPrefs(sbx) {
     return {
-      info: sbx.extendedSettings.info || times.days(6).hours
-      , warn: sbx.extendedSettings.warn || (times.days(7).hours - 4)
-      , urgent: sbx.extendedSettings.urgent || (times.days(7).hours - 2)
+      info: sbx.extendedSettings.info || times.days(8).hours
+      , warn: sbx.extendedSettings.warn || (times.days(9).hours)
+      , urgent: sbx.extendedSettings.urgent || (times.days(10).hours - 4)
       , enableAlerts: sbx.extendedSettings.enableAlerts || false
     };
   };


### PR DESCRIPTION
Changing default SAGE warn and urgent threshold defaults to be useful for 10 day sensors rather than 7 day sensors from the G5 era. SAGE pill turns yellow at day 9 and red 4 hours before expiration of 10 days.

Once G6 is retired, consider setting WARN to 10 days and URGENT to 10.5 days.